### PR TITLE
Add critical-section dependency on PACs

### DIFF
--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -58,6 +58,10 @@ cortex-m = "0.7.3"
 optional = true
 version = "0.7.0"
 
+[dependencies.critical-section]
+optional = true
+version = "1.1.1"
+
 [package.metadata.docs.rs]
 features = {docs_features}
 default-target = "{doc_target}"
@@ -116,7 +120,7 @@ compile the device(s) you want. To use, in your Cargo.toml:
 ```toml
 [dependencies.{crate}]
 version = "{version}"
-features = ["{device}", "rt"]
+features = ["{device}", "rt", "critical-section"]
 ```
 
 The `rt` feature is optional and brings in support for `cortex-m-rt`.


### PR DESCRIPTION
SVD2Rust update to 1.27 added the usage of critical-section to take ownership of the Peripherals struct, which means we need to add this dependency to the crates.