### PR TITLE
Update vendors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,13 +44,13 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: ${{ runner.os }}-svd2rust-0.27.2
+          key: ${{ runner.os }}-svd2rust-0.30.1
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1
         with:
           crate: svd2rust
-          version: 0.27.2
+          version: 0.30.1
       - name: Copy svd2rust to cache directory
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -31,13 +31,13 @@ jobs:
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: ${{ runner.os }}-cargo-binaries-0.27.2
+          key: ${{ runner.os }}-cargo-binaries-0.30.1
       - name: Install svd2rust
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: svd2rust --version 0.27.2
+          args: svd2rust --version 0.30.1
       - name: Install form
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Updated to `svd2rust` 0.30.1.
 - GD32E103
   - Added some more field details to `RCU.INT`.
 - GD32E23x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Updated to `critical-section` to 1.1.2.
+- Updated to `cortex-m-rt` to 0.7.3.
+- Updated to `cortex-m` to 0.7.7.
 - Updated to `svd2rust` 0.30.1.
 - GD32E103
   - Added some more field details to `RCU.INT`.

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -17,7 +17,7 @@ import re
 import yaml
 
 VERSION = "0.7.0"
-SVD2RUST_VERSION = "0.27.2"
+SVD2RUST_VERSION = "0.30.1"
 
 CRATE_DOC_FEATURES = {
     "gd32e1": ["rt", "gd32e103"],

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -52,15 +52,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 vcell = "0.1.3"
-cortex-m = "0.7.6"
+cortex-m = "0.7.7"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.7.2"
+version = "0.7.3"
 
 [dependencies.critical-section]
 optional = true
-version = "1.1.1"
+version = "1.1.2"
 
 [package.metadata.docs.rs]
 features = {docs_features}


### PR DESCRIPTION
svd2rust version 0.30.1 fixes the alias implementation bugs (https://github.com/rust-embedded/svd2rust/issues/705) we had for #40 
I also updated some crate dependencies :)