### PR TITLE
Re-enable re-export of interrupt macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Re-enabled re-export of `cortex_m_rt::interrupt` macro.
+
 ## [0.9.0]
 
 - Updated to `svd2rust` 0.32.0.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ crates:
 define crate_template
 $(1)/src/%/mod.rs: svd/%.svd.patched $(1)/Cargo.toml
 	mkdir -p $$(@D)
-	cd $$(@D); svd2rust -m -g -i ../../../$$<
+	cd $$(@D); svd2rust --reexport-interrupt -m -g -i ../../../$$<
 	rustfmt --config-path="rustfmt.toml" $$@
 	sed -i.bak "s/crate::timer/crate::$$(*F)::timer/" $$@
 	rm $$@.bak


### PR DESCRIPTION
This is apparently deprecated in the latest version of svd2rust, but it doesn't seem to be possible to use interrupts without it.

See https://github.com/rust-embedded/svd2rust/issues/830.